### PR TITLE
added an example for how to use container linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository contains example deployments of DC/OS using multiple features or
 
 - AWS
     - [Using a default/own VPC](./aws/default-vpc)
-    - No public IPs
-    - Using Core OS
+    - [No public IPs](./aws/private-subnets)
+    - [Using Core OS](./aws/cores)
 - GCP
 - Azure
 - On-Prem

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains example deployments of DC/OS using multiple features or
 
 - AWS
     - [Using a default/own VPC](./aws/default-vpc)
-    - No public IPs
+    - [No public IPs](./aws/private-subnets)
     - Using Core OS
 - GCP
 - Azure

--- a/aws/coreos/README.md
+++ b/aws/coreos/README.md
@@ -1,0 +1,88 @@
+# Create a DC/OS Cluster with Container Linux
+In this example we will create an DC/OS cluster using Container Linux (formerly CoreOS). All it takes is defining the correct version from the selection below as the dcos_instance_os and it will find the correct AMI based on your region and version of Container Linux. 
+
+# [`main.tf`](./main.tf?raw=1)
+Just do an copy of [`main.tf`](./main.tf?raw=1) in a local folder and `cd` into it. 
+
+* NOTE: 
+
+# `cluster.tfvars`
+For this cluster we need to set your ssh public key..
+
+if you already have a ssh key. Just read the public key content and assign it to the terraform variable. Also you should set a cluster name. It gets tagged with this name so you can easily identify the nodes of your cluster.
+
+## Requiered Variables
+- `ssh_public_key` SSH public key to be used for deploying the cluster.
+- `dcos_instance_os` Defines the OS of all the instances. Select from list below.
+
+## Currently offered versions of Container Linux (CoreOS)
+These are the currently supported versions for the terraform modules. Please consult the [DC/OS Supported OS matrix](https://docs.mesosphere.com/version-policy/#dcos-platform-version-compatibility-matrix). Please note that this list may be out of date and will continously be updated based on supported OS to version of DC/OS. 
+
+- `coreos_1235.9.0`
+- `coreos_1465.8.0`
+- `coreos_1576.5.0`
+- `coreos_835.13.0`
+
+
+
+## Suggested commands
+
+```bash
+$ terraform init
+# Add SSH key to vars file
+$ echo "ssh_public_key=\"$(cat ~/.ssh/id_rsa.pub)\"" >> cluster.tfvars
+# Add the desired version from above
+$ echo "dcos_instance_os=\"coreos_1235.9.0\"" >> cluster.tfvars
+# we at mesosphere have to tag our instances with an owner and an expire date.
+$ echo "tags={Owner = \"$(whoami)\", Expires = \"2h\"}" >> cluster.tfvars
+```
+
+# AWS
+DC/OS Terraform is using the [AWS Default Credentials Chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). To change REGION or Account you can use the [AWS Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html)
+
+## Change region (optional)
+Changing the default region ( the one you specified with `aws configure` )
+
+```bash
+# Change the default region to us-east-1
+$ export AWS_DEFAULT_REGION="us-east-1" 
+```
+
+## Change profile (optional)
+If you want to use a second profile for deploying you can use `AWS_PROFILE` variable
+
+```bash
+$ export AWS_PROFILE=my-second-profile
+```
+
+# terraform init
+Doing terraform init lets terraform download all the needed modules to spawn DC/OS Cluster on AWS
+
+```bash
+$ terraform init
+```
+
+# terraform plan
+We expect your aws environment is properly setup. Check it with issuing `aws sts get-caller-identity`.
+
+We now create the terraform plan which gets applied later on.
+
+```bash
+$ terraform plan --var-file cluster.tfvars -out=cluster.plan
+```
+
+# terraform apply
+Now we're applying our plan
+
+```bash
+$ terraform apply "cluster.plan"
+```
+
+in the output section you will find the hostname of your cluster. With this hostname you'll be able to access the cluster.
+
+# terraform destroy
+If you want to destroy your cluster again use
+
+```bash
+$ terraform destroy --var-file cluster.tfvars
+```

--- a/aws/coreos/main.tf
+++ b/aws/coreos/main.tf
@@ -1,0 +1,36 @@
+///////////////// VARIABLES /////////////////
+variable "ssh_public_key" {
+  description = <<EOF
+Specify a SSH public key in authorized keys format (e.g. "ssh-rsa ..") to be used with the instances. Make sure you added this key to your ssh-agent
+EOF
+}
+
+variable "dcos_instance_os" {
+  description = "Version of Container Linux we are going to use"
+}
+
+/////////////// END VARIABLES //////////////
+
+module "dcos" {
+  source  = "dcos-terraform/dcos/aws"
+  version = "~> 0.0"
+
+  cluster_name = "coreos-cluster"
+  ssh_public_key = "${var.ssh_public_key}"
+
+  num_masters = "3"
+  num_private_agents = "7"
+  num_public_agents = "1"
+
+  dcos_type = "open"
+  dcos_instance_os = "${var.dcos_instance_os}"
+  dcos_version = "1.11.4"
+  dcos_install_mode = "install"
+  
+  # dcos_license_key_contents = ""
+}
+
+/////////////// OUTPUT //////////////
+output "cluster-address" {
+  value = "${module.dcos.masters-loadbalancer}"
+}

--- a/aws/coreos/main.tf
+++ b/aws/coreos/main.tf
@@ -19,13 +19,12 @@ module "dcos" {
   ssh_public_key = "${var.ssh_public_key}"
 
   num_masters = "3"
-  num_private_agents = "7"
+  num_private_agents = "3"
   num_public_agents = "1"
 
   dcos_type = "open"
   dcos_instance_os = "${var.dcos_instance_os}"
-  dcos_version = "1.11.4"
-  dcos_install_mode = "install"
+
   
   # dcos_license_key_contents = ""
 }

--- a/aws/private-subnets/README.md
+++ b/aws/private-subnets/README.md
@@ -2,7 +2,9 @@
 In this example we will create an DC/OS cluster using an already existing VPC which uses Private Subnets. The `main.tf` file in this repository is our example implementation using a VPC with Private Subnets. In this example we do not allow any Public IP address associtation with any resource.
 
 # [`main.tf`](./main.tf?raw=1)
-Just do an copy of [`main.tf`](./main.tf?raw=1) in a local folder and `cd` into it.
+Just do an copy of [`main.tf`](./main.tf?raw=1) in a local folder and `cd` into it. 
+
+* NOTE: 
 
 # `cluster.tfvars`
 For this cluster we need to set your ssh public key..
@@ -25,6 +27,34 @@ $ echo "admin_ips=[\"1.2.3.0/24\", \"3.2.1.0/24\"]" >> cluster.tfvars
 $ echo "tags={Owner = \"$(whoami)\", Expires = \"2h\"}" >> cluster.tfvars
 ```
 
+## Setting VPC/Subnets
+Out of the box, this example uses the default VPC and all of the subnets from that VPC. You may modify these entries to specific "id" or by using Tags to specify. Examples are commented our in the main.tf. See example below for using tags:
+
+```bash
+# instead of default you could specify an ID or Tags. 
+# https://www.terraform.io/docs/providers/aws/d/vpc.html
+data "aws_vpc" "default" {
+  provider = "aws"
+
+  default = false # or false if not default and use either id or tags below
+  #id = ""        # If false you can use specific ID of VPC OR use tags 
+  tags {
+    Name = "test-private-vpc"
+  }
+}
+
+# You could use tags if you only want a subset of subnets such as a subnet with only Private Subnet
+# https://www.terraform.io/docs/providers/aws/d/subnet_ids.html
+data "aws_subnet_ids" "default_subnets" {
+  provider = "aws"
+
+  vpc_id = "${data.aws_vpc.default.id}" 
+  #id = "[]"        # You can use the Specific ID(s) OR use tags
+  tags {
+    Name = "test-private-vpc-subnet"
+  }
+}
+```
 
 ## Local Variables
 We've added intermediate local variables for all module output and inputs. This will make it easy replacing parts of the modules with your own code.

--- a/aws/private-subnets/README.md
+++ b/aws/private-subnets/README.md
@@ -1,0 +1,80 @@
+# Create a DC/OS Cluster using an existing VPC and Private Subnets
+In this example we will create an DC/OS cluster using an already existing VPC which uses Private Subnets. The `main.tf` file in this repository is our example implementation using a VPC with Private Subnets. In this example we do not allow any Public IP address associtation with any resource.
+
+# [`main.tf`](./main.tf?raw=1)
+Just do an copy of [`main.tf`](./main.tf?raw=1) in a local folder and `cd` into it.
+
+# `cluster.tfvars`
+For this cluster we need to set your ssh public key..
+
+if you already have a ssh key. Just read the public key content and assign it to the terraform variable. Also you should set a cluster name. It gets tagged with this name so you can easily identify the nodes of your cluster.
+
+## Requiered Variables
+- `admin_ips` List of CIDR addresses who get access to the cluster.
+- `ssh_public_key` SSH public key to be used for deploying the cluster.
+
+## Suggested commands
+
+```bash
+$ terraform init
+# Add SSH key to vars file
+$ echo "ssh_public_key=\"$(cat ~/.ssh/id_rsa.pub)\"" >> cluster.tfvars
+# Set the Subnet of where connections to the Cluster will be made (Your Local Subnet)
+$ echo "admin_ips=[\"1.2.3.0/24\", \"3.2.1.0/24\"]" >> cluster.tfvars
+# we at mesosphere have to tag our instances with an owner and an expire date.
+$ echo "tags={Owner = \"$(whoami)\", Expires = \"2h\"}" >> cluster.tfvars
+```
+
+
+## Local Variables
+We've added intermediate local variables for all module output and inputs. This will make it easy replacing parts of the modules with your own code.
+
+# AWS
+DC/OS Terraform is using the [AWS Default Credentials Chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). To change REGION or Account you can use the [AWS Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html)
+
+## Change region (optional)
+Changing the default region ( the one you specified with `aws configure` )
+
+```bash
+# Change the default region to us-east-1
+$ export AWS_DEFAULT_REGION="us-east-1" 
+```
+
+## Change profile (optional)
+If you want to use a second profile for deploying you can use `AWS_PROFILE` variable
+
+```bash
+$ export AWS_PROFILE=my-second-profile
+```
+
+# terraform init
+Doing terraform init lets terraform download all the needed modules to spawn DC/OS Cluster on AWS
+
+```bash
+$ terraform init
+```
+
+# terraform plan
+We expect your aws environment is properly setup. Check it with issuing `aws sts get-caller-identity`.
+
+We now create the terraform plan which gets applied later on.
+
+```bash
+$ terraform plan --var-file cluster.tfvars -out=cluster.plan
+```
+
+# terraform apply
+Now we're applying our plan
+
+```bash
+$ terraform apply "cluster.plan"
+```
+
+in the output section you will find the hostname of your cluster. With this hostname you'll be able to access the cluster.
+
+# terraform destroy
+If you want to destroy your cluster again use
+
+```bash
+$ terraform destroy --var-file cluster.tfvars
+```

--- a/aws/private-subnets/main.tf
+++ b/aws/private-subnets/main.tf
@@ -1,0 +1,379 @@
+///////////////// VARIABLES /////////////////
+//
+// Only ssh_public_key is mandatory
+//
+////////////////////////////////////////////
+variable "ssh_public_key" {
+  description = <<EOF
+Specify a SSH public key in authorized keys format (e.g. "ssh-rsa ..") to be used with the instances. Make sure you added this key to your ssh-agent
+EOF
+}
+
+variable "dcos_version" {
+  description = "Specify the availability zones to be used"
+  default     = "1.11.3"
+}
+
+variable "cluster_name" {
+  description = "Name of the DC/OS cluster"
+  default     = "dcos-default-vpc"
+}
+
+variable "num_masters" {
+  description = "Specify the amount of masters. For redundancy you should have at least 3"
+  default     = 3
+}
+
+variable "num_private_agents" {
+  description = "Specify the amount of private agents. These agents will provide your main resources"
+  default     = 2
+}
+
+variable "num_public_agents" {
+  description = "Specify the amount of public agents. These agents will host marathon-lb and edgelb"
+  default     = 1
+}
+
+variable "dcos_license_key_contents" {
+  default     = ""
+  description = "[Enterprise DC/OS] used to privide the license key of DC/OS for Enterprise Edition. Optional if license.txt is present on bootstrap node."
+}
+
+variable "dcos_type" {
+  default = "open"
+}
+
+variable "tags" {
+  description = "Add custom tags to all resources"
+  type        = "map"
+  default     = {}
+}
+
+variable "admin_ips" {
+  description = "List of CIDR admin IPs"
+  type        = "list"
+}
+
+variable "aws_associate_public_ip_address" {
+  description = "Whether or not to add a public IP to an instance"
+  default = "false"
+}
+
+
+
+////////////////////////////////////////////
+/////////////// END VARIABLES //////////////
+////////////////////////////////////////////
+
+provider "aws" {
+}
+
+// create a ssh-key-pair.
+resource "aws_key_pair" "deployer" {
+  provider = "aws"
+
+  key_name   = "${var.cluster_name}-deployer-key"
+  public_key = "${var.ssh_public_key}"
+}
+
+// select our default VPC.
+// instead of default you could specify an ID or Tags. 
+// https://www.terraform.io/docs/providers/aws/d/vpc.html
+data "aws_vpc" "default" {
+  provider = "aws"
+
+  default = false # or false if not default and use either id or tags below
+  #id = ""
+  tags {
+    Name = "test-private-vpc"
+  }
+}
+
+// we want to use all the subnets in this VPC
+// You could use tags if you only want a subset of subnets such as a subnet with only Private Subnet
+// https://www.terraform.io/docs/providers/aws/d/subnet_ids.html
+data "aws_subnet_ids" "default_subnets" {
+  provider = "aws"
+
+  vpc_id = "${data.aws_vpc.default.id}"
+  
+  tags {
+    Name = "test-private-vpc-subnet"
+  }
+
+}
+
+// we use intermediate local variables. So whenever it is needed to replace
+// or drop a modules it is easier to change just the local variable instead
+// of all other references
+locals {
+  key_name     = "${aws_key_pair.deployer.key_name}"
+  vpc_id       = "${data.aws_vpc.default.id}"
+  subnet_range = "${data.aws_vpc.default.cidr_block}"
+  subnet_ids   = ["${data.aws_subnet_ids.default_subnets.ids}"]
+}
+
+// Firewall. Create policies for instances and load balancers.
+// https://registry.terraform.io/modules/dcos-terraform/security-groups/aws
+module "dcos-security-groups" {
+  source = "dcos-terraform/security-groups/aws"
+
+  # version = "0.0.1"
+  providers = {
+    aws = "aws"
+  }
+
+  vpc_id       = "${local.vpc_id}"
+  subnet_range = "${local.subnet_range}"
+  cluster_name = "${var.cluster_name}"
+  admin_ips    = ["${var.admin_ips}"]
+}
+
+// we use intermediate local variables. So whenever it is needed to replace
+// or drop a modules it is easier to change just the local variable instead
+// of all other references
+locals {
+  instance_security_groups             = ["${list(module.dcos-security-groups.internal, module.dcos-security-groups.admin)}"]
+  security_groups_elb_masters          = ["${list(module.dcos-security-groups.admin,module.dcos-security-groups.internal)}"]
+  security_groups_elb_masters_internal = ["${list(module.dcos-security-groups.internal)}"]
+  security_groups_elb_public_agents    = ["${list(module.dcos-security-groups.admin,module.dcos-security-groups.internal)}"]
+}
+
+// Permissions creates instances profiles so you could use Rexray and Kubernetes with AWS support
+// These set of IAM Rules will be applied as Instance Profiles. They will enable Rexray to maintain
+// volumes in your cluster
+// https://registry.terraform.io/modules/dcos-terraform/iam/aws
+module "dcos-iam" {
+  source  = "dcos-terraform/iam/aws"
+  version = "~> 0.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  cluster_name = "${var.cluster_name}"
+}
+
+// This spawning the Bootstrap node which will be used as the internal source for the installer.
+// https://registry.terraform.io/modules/dcos-terraform/bootstrap/aws
+module "dcos-bootstrap-instance" {
+  source  = "dcos-terraform/bootstrap/aws"
+  version = "~> 0.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  cluster_name = "${var.cluster_name}"
+
+  aws_subnet_ids         = ["${local.subnet_ids}"]
+  aws_security_group_ids = ["${local.instance_security_groups}"]
+  aws_key_name           = "${local.key_name}"
+  aws_associate_public_ip_address = "${var.aws_associate_public_ip_address}"
+
+  tags = "${var.tags}"
+}
+
+// This module creates the master instances of your DC/OS cluster. If neccessary you can change the instance type or OS.
+// https://registry.terraform.io/modules/dcos-terraform/masters/aws
+module "dcos-master-instances" {
+  source  = "dcos-terraform/masters/aws"
+  version = "~> 0.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  cluster_name = "${var.cluster_name}"
+
+  aws_subnet_ids         = ["${local.subnet_ids}"]
+  aws_security_group_ids = ["${local.instance_security_groups}"]
+  aws_key_name           = "${local.key_name}"
+  aws_associate_public_ip_address = "${var.aws_associate_public_ip_address}"
+
+  num_masters = "${var.num_masters}"
+
+  tags = "${var.tags}"
+}
+
+// This module create the private agent instances of your DC/OS cluster. If neccessary you can change the instance type or OS.
+// https://registry.terraform.io/modules/dcos-terraform/private-agents/aws
+module "dcos-privateagent-instances" {
+  source  = "dcos-terraform/private-agents/aws"
+  version = "~> 0.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  cluster_name = "${var.cluster_name}"
+
+  aws_subnet_ids         = ["${local.subnet_ids}"]
+  aws_security_group_ids = ["${local.instance_security_groups}"]
+  aws_key_name           = "${local.key_name}"
+  aws_associate_public_ip_address = "${var.aws_associate_public_ip_address}"
+
+  num_private_agents = "${var.num_private_agents}"
+
+  tags = "${var.tags}"
+}
+
+// This module create the public agent instances of your DC/OS cluster. If neccessary you can change the instance type or OS.
+// https://registry.terraform.io/modules/dcos-terraform/public-agents/aws
+module "dcos-publicagent-instances" {
+  source  = "dcos-terraform/public-agents/aws"
+  version = "~> 0.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  cluster_name = "${var.cluster_name}"
+
+  aws_subnet_ids         = ["${local.subnet_ids}"]
+  aws_security_group_ids = ["${local.instance_security_groups}"]
+  aws_key_name           = "${local.key_name}"
+  aws_associate_public_ip_address = "${var.aws_associate_public_ip_address}"
+  tags                   = "${var.tags}"
+
+  num_public_agents = "${var.num_public_agents}"
+
+  tags = "${var.tags}"
+}
+
+// we use intermediate local variables. So whenever it is needed to replace
+// or drop a modules it is easier to change just the local variable instead
+// of all other references
+locals {
+  bootstrap_ip         = "${module.dcos-bootstrap-instance.private_ip}"
+  bootstrap_private_ip = "${module.dcos-bootstrap-instance.private_ip}"
+  bootstrap_os_user    = "${module.dcos-bootstrap-instance.os_user}"
+
+  master_ips         = ["${module.dcos-master-instances.private_ips}"]
+  master_private_ips = ["${module.dcos-master-instances.private_ips}"]
+  masters_os_user    = "${module.dcos-master-instances.os_user}"
+  master_instances   = ["${module.dcos-master-instances.instances}"]
+
+  private_agent_ips      = ["${module.dcos-privateagent-instances.private_ips}"]
+  private_agents_os_user = "${module.dcos-privateagent-instances.os_user}"
+
+  public_agent_ips       = ["${module.dcos-publicagent-instances.private_ips}"]
+  public_agents_os_user  = "${module.dcos-publicagent-instances.os_user}"
+  public_agent_instances = ["${module.dcos-publicagent-instances.instances}"]
+}
+
+// Load balancers is providing three load balancers.
+// - public master load balancer
+//   this load balancer is meant to be used as your main access to the cluster and will lead you to the DC/OS Frontend.
+//   you can specify masters_acm_cert_arn to use an ACM certificate for proper SSL termination.
+//   https://registry.terraform.io/modules/dcos-terraform/elb-dcos/aws
+// - internal master load balancer
+//   this load balancer can be used for accessing the master internally in the cluster.
+//   https://registry.terraform.io/modules/dcos-terraform/elb-dcos/aws
+// - public agents load balancer
+//   This load balancer is meant to be the main public access point into your application. If you use marathon-lb or edge-lb
+//   it will make sure your custermers will allways be able to access one of the public agents even if one failed.
+//   you can specify masters_acm_cert_arn to use an ACM certificate for proper SSL termination.
+//   https://registry.terraform.io/modules/dcos-terraform/elb-dcos/aws
+module "dcos-elb" {
+  source  = "dcos-terraform/elb-dcos/aws"
+  version = "~> 0.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  cluster_name = "${var.cluster_name}"
+  subnet_ids   = ["${data.aws_subnet_ids.default_subnets.ids}"]
+
+  security_groups_masters          = ["${local.security_groups_elb_masters}"]
+  security_groups_masters_internal = ["${local.security_groups_elb_masters_internal}"]
+  security_groups_public_agents    = ["${local.security_groups_elb_public_agents}"]
+
+  master_instances = ["${local.master_instances}"]
+
+  public_agent_instances = ["${local.public_agent_instances}"]
+
+  tags = "${var.tags}"
+}
+
+// we use intermediate local variables. So whenever it is needed to replace
+// or drop a modules it is easier to change just the local variable instead
+// of all other references
+locals {
+  elb_masters_dns_name = "${module.dcos-elb.masters_dns_name}"
+}
+
+// DC/OS Install module takes a list of public and private ip addresses of each of the node type to install.
+// - <node type>_ip - This is the "public" address of the given node type. Public in this case mean the address is reachable from the system running terraform. Public and private address could be the same.
+// - <node type>_private_ip - These are the addresses the cluster could reach its nodes internally.
+// - <node type>_os_user - specifies the user used for sshing into the nodes.
+// https://registry.terraform.io/modules/dcos-terraform/dcos-install-remote-exec/null
+// DC/OS Options. Install takes also all the options for runnign Genconfig. Whatever you want to change at the DC/OS config needs to be
+// specified in this module. A good description could be found here: https://registry.terraform.io/modules/dcos-terraform/dcos-core/template
+module "dcos-install" {
+  source  = "dcos-terraform/dcos-install-remote-exec/null"
+  version = "~> 0.0"
+
+  # bootstrap
+  bootstrap_ip         = "${local.bootstrap_ip}"
+  bootstrap_private_ip = "${local.bootstrap_private_ip}"
+  bootstrap_os_user    = "${local.bootstrap_os_user}"
+
+  # master
+  master_ips         = ["${local.master_ips}"]
+  master_private_ips = ["${local.master_private_ips}"]
+  masters_os_user    = "${local.masters_os_user}"
+  num_masters        = "${var.num_masters}"
+
+  # private agent
+  private_agent_ips      = ["${local.private_agent_ips}"]
+  private_agents_os_user = "${local.private_agents_os_user}"
+  num_private_agents     = "${var.num_private_agents}"
+
+  # public agent
+  public_agent_ips      = ["${local.public_agent_ips}"]
+  public_agents_os_user = "${local.public_agents_os_user}"
+  num_public_agents     = "${var.num_public_agents}"
+
+  # DC/OS options
+  dcos_install_mode = "install"
+  dcos_cluster_name = "${var.cluster_name}"
+  dcos_version      = "${var.dcos_version}"
+
+  dcos_ip_detect_public_contents = <<EOF
+#!/bin/sh
+set -o nounset -o errexit
+
+curl -fsSL http://whatismyip.akamai.com/
+EOF
+
+  dcos_ip_detect_contents = <<EOF
+#!/bin/sh
+# Example ip-detect script using an external authority
+# Uses the AWS Metadata Service to get the node's internal
+# ipv4 address
+curl -fsSL http://169.254.169.254/latest/meta-data/local-ipv4
+EOF
+
+  dcos_fault_domain_detect_contents = <<EOF
+#!/bin/sh
+set -o nounset -o errexit
+
+METADATA="$(curl http://169.254.169.254/latest/dynamic/instance-identity/document 2>/dev/null)"
+REGION=$(echo $METADATA | grep -Po "\"region\"\s+:\s+\"(.*?)\"" | cut -f2 -d:)
+ZONE=$(echo $METADATA | grep -Po "\"availabilityZone\"\s+:\s+\"(.*?)\"" | cut -f2 -d:)
+
+echo "{\"fault_domain\":{\"region\":{\"name\": $REGION},\"zone\":{\"name\": $ZONE}}}"
+EOF
+
+  dcos_type                      = "${var.dcos_type}"
+  dcos_license_key_contents      = "${var.dcos_license_key_contents}"
+  dcos_master_discovery          = "static"
+  dcos_exhibitor_storage_backend = "static"
+}
+
+output "elb.masters_dns_name" {
+  description = "This is the load balancer address to access the DC/OS UI"
+  value       = "${local.elb_masters_dns_name}"
+}

--- a/aws/private-subnets/main.tf
+++ b/aws/private-subnets/main.tf
@@ -82,11 +82,11 @@ resource "aws_key_pair" "deployer" {
 data "aws_vpc" "default" {
   provider = "aws"
 
-  default = false # or false if not default and use either id or tags below
+  default = true # or false if not default and use either id or tags below
   #id = ""
-  tags {
-    Name = "test-private-vpc"
-  }
+  #tags {
+    #Name = "test-private-vpc"
+  #}
 }
 
 // we want to use all the subnets in this VPC
@@ -96,11 +96,10 @@ data "aws_subnet_ids" "default_subnets" {
   provider = "aws"
 
   vpc_id = "${data.aws_vpc.default.id}"
-  
-  tags {
-    Name = "test-private-vpc-subnet"
-  }
-
+  #id = ""
+  #tags {
+    #Name = "test-private-vpc-subnet"
+  #}
 }
 
 // we use intermediate local variables. So whenever it is needed to replace


### PR DESCRIPTION
Added Docs and Example of how to use the dcos_instance_os variable to use version of Container Linux. Still need to submit a PR and update the version to fix our support matrix for container linux. 